### PR TITLE
Allow new versions (^7.0 or ^8.0) of illuminate/support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "illuminate/support": "^5.4||^6.0",
+        "illuminate/support": "^5.4||^6.0||^7.0||^8.0",
         "bjeavons/zxcvbn-php": "^0.3"
     },
     "require-dev": {


### PR DESCRIPTION
Sorry, I realised that I should have allowed the latest versions of illuminate/support too (^7.0 and ^8.0).

Thanks!
Ben