### PR TITLE
Feature/add php8 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,4 +80,5 @@ jobs:
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1
         with:
+          file: ./clover.xml
           fail_ci_if_error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,14 +10,14 @@ jobs:
       max-parallel: 15
       fail-fast: false
       matrix:
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3']
+        php: ['7.2', '7.3', '7.4', '8.0']
 
     steps:
       - name: Checkout
         uses: actions/checkout@master
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.1.4
+        uses: shivammathur/setup-php@2.9.0
         with:
           php-version: ${{ matrix.php }}
           coverage: none
@@ -47,7 +47,7 @@ jobs:
       max-parallel: 15
       fail-fast: false
       matrix:
-        php: ['7.4']
+        php: ['8.0']
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,9 +76,3 @@ jobs:
 
       - name: Run Unit Tests
         run: php vendor/bin/phpunit --coverage-clover=clover.xml
-
-      - name: Upload Coverage Report
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./clover.xml
-          fail_ci_if_error: true

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "php-parallel-lint/php-parallel-lint": "^0.9.2||^1.2",
         "phpmd/phpmd": "^2.6",
         "phpunit/phpunit": "^5.7||^9.5",
-        "spatie/ray": "^1.14",
         "squizlabs/php_codesniffer": "^2.8||^3.5.8"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.2",
         "illuminate/support": "^5.4||^6.0||^7.0||^8.0",
         "bjeavons/zxcvbn-php": "^0.3||1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,17 @@
     "require": {
         "php": ">=5.6",
         "illuminate/support": "^5.4||^6.0||^7.0||^8.0",
-        "bjeavons/zxcvbn-php": "^0.3"
+        "bjeavons/zxcvbn-php": "^0.3||1.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.1",
-        "jakub-onderka/php-console-highlighter": "^0.3.2",
-        "jakub-onderka/php-parallel-lint": "^0.9.2",
-        "orchestra/testbench": "^3.4.10",
+        "orchestra/testbench": "~3.4.10 || ~3.6.7 || ~3.7.8 || ~3.8.6 || ^4.8 || ^5.2 || ^6.0",
+        "php-parallel-lint/php-console-highlighter": "^0.3.2",
+        "php-parallel-lint/php-parallel-lint": "^0.9.2||^1.2",
         "phpmd/phpmd": "^2.6",
-        "phpunit/phpunit": "^5.7",
-        "squizlabs/php_codesniffer": "^2.8"
+        "phpunit/phpunit": "^5.7||^9.5",
+        "spatie/ray": "^1.14",
+        "squizlabs/php_codesniffer": "^2.8||^3.5.8"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,26 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         beStrictAboutCoversAnnotation="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         verbose="true"
->
-    <testsuites>
-        <testsuite name="Unit Tests">
-            <directory>tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory>vendor/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd" bootstrap="vendor/autoload.php" backupGlobals="false" beStrictAboutCoversAnnotation="true" beStrictAboutOutputDuringTests="true" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutTodoAnnotatedTests="true" verbose="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <exclude>
+      <directory>vendor/</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit Tests">
+      <directory>tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/resources/lang/de/validation.php
+++ b/resources/lang/de/validation.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-
+    'suggestion'         => 'Fügen Sie ein oder zwei weitere Wörter hinzu. Gelegentliche Wörter sind besser',
     'bruteforce'         => 'Das Passwort ist durch Probieren leicht zu erraten. Verwenden Sie Zeichenklassen (Buchstaben, Zahlen, Sonderzeichen).',
     'predictable'        => 'Vorhersagbare Ersetzungen wie "@" für "a" oder "$" für "s" sind leicht zu erraten.',
     'sequence'           => 'Sequenzen wie "ABC" oder "123" sind leicht zu erraten.',

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-
+    'suggestion'         => 'Add another word or two. Uncommon words are better',
     'bruteforce'         => 'This password is easy to brute-force. Use different character classes (letters, numbers, special characters).',
     'predictable'        => 'Predictable substitutions such as "@" for "a" or "$" for "s" are easy to guess',
     'sequence'           => 'Sequences like "ABC" or "123" are easy to guess',
@@ -17,5 +17,4 @@ return [
     'top_100'            => 'This is in the top-100 most common passwords',
     'digits'             => 'Adding a series of digits does not improve security',
     'reused'             => 'Re-using information such as your name, username or email in the password is not secure',
-
 ];

--- a/resources/lang/nl/validation.php
+++ b/resources/lang/nl/validation.php
@@ -1,16 +1,20 @@
-[
-        'predictable'        => 'Voorspelbare vervangende tekenens zoals "@" ipv "a" of "$" ipv "s" zijn makkerlijk te raden',
-        'sequence'           => 'Zinnen zoals "ABC" of "123" zijn makkerlijk te raden',
-        'repeat'             => 'Herhalende tekens zoals "AAA" of "111" zijn makkerlijk te raden',
-        'date'               => 'Datums zijn meestal makkerlijk te raden',
-        'year'               => 'Recente jaren zijn makkerlijk te raden',
-        'straight_spatial'   => 'Korte toetsenbord patronen zijn makkerlijk te raden',
-        'spatial_with_turns' => 'Op een volgende tekens zijn makkerlijk te raden',
-        'names'              => 'Namen zijn makkerlijk te raden',
-        'common'             => 'Wachtwoord lijkt te veel op een veelgebruikt wachtwoord',
-        'very_common'        => 'Wachtwoord komt voor in veelgebruikte wachtwoorden',
-        'top_10'             => 'Wachtwoord komt voor in de top 10 meest gebruikte wachtwoorden',
-        'top_100'            => 'Wachtwoord komt voor in de top 100 meest gebruikte wachtwoorden',
-        'digits'             => 'Een serie getallen verbetert het wachtwoord niet',
-        'reused'             => 'Gegevens zoals uw naam of wachtwoord gebruiken in het wachtwoord is niet toegestaan',
-]
+<?php
+
+return [
+    'suggestion'         => 'Voeg nog een paar woorden toe. Ongewone woorden zijn beter',
+    'bruteforce'         => 'Dit wachtwoord is gemakkelijk bruut te forceren. Gebruik verschillende tekenklassen (letters, cijfers, speciale tekens).',
+    'predictable'        => 'Voorspelbare vervangende tekenens zoals "@" ipv "a" of "$" ipv "s" zijn makkerlijk te raden',
+    'sequence'           => 'Zinnen zoals "ABC" of "123" zijn makkerlijk te raden',
+    'repeat'             => 'Herhalende tekens zoals "AAA" of "111" zijn makkerlijk te raden',
+    'date'               => 'Datums zijn meestal makkerlijk te raden',
+    'year'               => 'Recente jaren zijn makkerlijk te raden',
+    'straight_spatial'   => 'Korte toetsenbord patronen zijn makkerlijk te raden',
+    'spatial_with_turns' => 'Op een volgende tekens zijn makkerlijk te raden',
+    'names'              => 'Namen zijn makkerlijk te raden',
+    'common'             => 'Wachtwoord lijkt te veel op een veelgebruikt wachtwoord',
+    'very_common'        => 'Wachtwoord komt voor in veelgebruikte wachtwoorden',
+    'top_10'             => 'Wachtwoord komt voor in de top 10 meest gebruikte wachtwoorden',
+    'top_100'            => 'Wachtwoord komt voor in de top 100 meest gebruikte wachtwoorden',
+    'digits'             => 'Een serie getallen verbetert het wachtwoord niet',
+    'reused'             => 'Gegevens zoals uw naam of wachtwoord gebruiken in het wachtwoord is niet toegestaan',
+];

--- a/tests/ZxcvbnTest.php
+++ b/tests/ZxcvbnTest.php
@@ -14,30 +14,16 @@ class ZxcvbnTest extends TestCase
     /** @var Factory */
     private $factory;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->factory = $this->app->make('validator');
     }
 
-    protected function getPackageProviders($app)
-    {
-        return [
-            ZxcvbnServiceProvider::class,
-        ];
-    }
-
-    protected function getPackageAliases($app)
-    {
-        return [
-            'Zxcvbn' => Zxcvbn::class
-        ];
-    }
-
     public function testBinding()
     {
-        $byName = $this->app->make('zxcvbn');
+        $byName  = $this->app->make('zxcvbn');
         $byClass = $this->app->make(ZxcvbnPhp::class);
 
         $this->assertInstanceOf(ZxcvbnPhp::class, $byName);
@@ -49,7 +35,7 @@ class ZxcvbnTest extends TestCase
         $result = Zxcvbn::passwordStrength('testing');
 
         $this->assertArrayHasKey('score', $result);
-        $this->assertArrayHasKey('match_sequence', $result);
+        $this->assertArrayHasKey('sequence', $result);
     }
 
     /**
@@ -97,6 +83,8 @@ class ZxcvbnTest extends TestCase
 
     /**
      * @dataProvider invalidPasswordDataProvider
+     * @param $value
+     * @param $expected
      */
     public function testItSetsTheCorrectErrorOnFailure($value, $expected)
     {
@@ -110,6 +98,13 @@ class ZxcvbnTest extends TestCase
 
         $this->assertFalse($validator->passes());
 
+        if ($validator->errors()->first() !== $translator->get('zxcvbn::validation.' . $expected)) {
+            ray("Value given", $value)->red();
+            ray("Validation Returned", $validator->errors()->first());
+            ray('Expected', $translator->get('zxcvbn::validation.' . $expected));
+            ray()->pause();
+        }
+
         $this->assertSame(
             $translator->get('zxcvbn::validation.' . $expected),
             $validator->errors()->first()
@@ -119,10 +114,10 @@ class ZxcvbnTest extends TestCase
     public function invalidPasswordDataProvider()
     {
         return [
-            ['halloduda', 'bruteforce'],           // Bruteforce
-            ['test123456', 'common'],              // Common
+            ['halloduda', 'suggestion'],           // suggestion
+            ['com', 'bruteforce'],                 // Bruteforce
             ['poiuytghjkl', 'spatial_with_turns'], // Simple keyboard pattern
-            ['poiuyt`', 'straight_spatial'],       // Straight row of keys
+            ['zxcvbnm,./`', 'straight_spatial'],   // Straight row of keys
             ['98761234', 'sequence'],              // Sequence of characters
             ['30/09/1983', 'date'],                // Date
             ['StephenBall', 'names'],              // Name
@@ -132,7 +127,7 @@ class ZxcvbnTest extends TestCase
             ['drowssap', 'very_common'],           // Simple reversal of one of the top passwords
             ['P4$$w0rd', 'predictable'],           // Predictable "l33t" substitutions
             ['seriously', 'common'],               // Dictionary word
-            [2019, 'year']                         // Recent year
+            [2019, 'year'],                        // Recent year
         ];
     }
 
@@ -142,7 +137,7 @@ class ZxcvbnTest extends TestCase
             'password' => 'rebelinblue',
             'username' => 'REBELinBLUE',
             'email'    => 'user@example.com',
-            'gender'   => 'male'
+            'gender'   => 'male',
         ];
 
         $validator = $this->factory->make($data, [
@@ -151,12 +146,25 @@ class ZxcvbnTest extends TestCase
 
         $this->assertFalse($validator->passes());
 
-
         $translator = $this->app->make('translator');
 
         $this->assertSame(
             $translator->get('zxcvbn::validation.reused'),
             $validator->errors()->first()
         );
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            ZxcvbnServiceProvider::class,
+        ];
+    }
+
+    protected function getPackageAliases($app)
+    {
+        return [
+            'Zxcvbn' => Zxcvbn::class,
+        ];
     }
 }

--- a/tests/ZxcvbnTest.php
+++ b/tests/ZxcvbnTest.php
@@ -98,13 +98,6 @@ class ZxcvbnTest extends TestCase
 
         $this->assertFalse($validator->passes());
 
-        if ($validator->errors()->first() !== $translator->get('zxcvbn::validation.' . $expected)) {
-            ray("Value given", $value)->red();
-            ray("Validation Returned", $validator->errors()->first());
-            ray('Expected', $translator->get('zxcvbn::validation.' . $expected));
-            ray()->pause();
-        }
-
         $this->assertSame(
             $translator->get('zxcvbn::validation.' . $expected),
             $validator->errors()->first()


### PR DESCRIPTION
Add support for PHP 8.
Match latest version of base PHP\Zxcvbn library to version 1.2.
Remove deprecated libraries and update to latest version.
Update validator and tests with changes on Zxcvbn library.
Add missing translation to Dutch & German.