### PR TITLE
Support Laravel 11.x and future

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "illuminate/support": "^5.4||^6.0||^7.0||^8.0||^9.0||^10.0",
+        "illuminate/support": ">=5.4",
         "bjeavons/zxcvbn-php": "^0.3||^1.2||^1.3"
     },
     "require-dev": {


### PR DESCRIPTION
Since Laravel API looks pretty stable over latest version (8,9,10,11) regarding validation area.
There is a good chance this package can traverse a decade.

Instead of simply adding ||^11.0 and again ||^12.0 in few months, I propose to simply stick with a >=5.4.